### PR TITLE
feat: Add JSON repair and tool call ID support for robust vLLM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,20 @@ Bielik models have been trained to generate structured outputs. Once the model i
 
 ## Tool Calling
 
-To use function/tool calling, you need to enable the extended chat template. This can be done using the provided [advanced chat template](https://github.com/speakleash/bielik-tools/blob/main/tools/bielik_advanced_chat_template.jinja) and [tool parser](https://github.com/speakleash/bielik-tools/blob/main/tools/bielik_vllm_tool_parser.py). Start vLLM with the following command:
+To use function/tool calling, you need to enable the extended chat template. This can be done using the provided [advanced chat template](https://github.com/speakleash/bielik-tools/blob/main/tools/bielik_advanced_chat_template.jinja) and [tool parser](https://github.com/speakleash/bielik-tools/blob/main/tools/bielik_vllm_tool_parser.py).
+
+### Installation
+
+vLLM should be installed with `json-repair` package (required for handling malformed JSON from Bielik):
 
 ```bash
-vllm serve Bielik-11B-v2.5-Instruct \
+uv tool install --python 3.12 vllm==0.10.2 --with json-repair
+```
+
+### Running vLLM with Tool Calling
+
+```bash
+vllm serve Bielik-11B-v2.6-Instruct \
     --enable-auto-tool-choice \
     --tool-parser-plugin ./bielik-tools/tools/bielik_vllm_tool_parser.py \
     --tool-call-parser bielik \

--- a/tools/bielik_advanced_chat_template.jinja
+++ b/tools/bielik_advanced_chat_template.jinja
@@ -58,7 +58,12 @@
         {%- set content = message["content"] if message["content"] else "" %}
         {{- "<|im_start|>assistant\n" + content }}
         {%- for tool_call in message.tool_calls %}
+            {%- set tc_id = tool_call.id if tool_call.id is defined else "" %}
+            {%- if tc_id %}
+            {{- '<tool_call>{"id": "' + tc_id + '", "name": "' + tool_call.function["name"] + '", "arguments": ' + tool_call.function["arguments"] | tojson + '}</tool_call>\n'}}
+            {%- else %}
             {{- '<tool_call>{"name": "' + tool_call.function["name"] + '", "arguments": ' + tool_call.function["arguments"] | tojson + '}</tool_call>\n'}}
+            {%- endif %}
         {%- endfor %}
         {{- "<|im_end|>\n" }}
     {%- elif message["role"] == "assistant" %}
@@ -69,7 +74,7 @@
         {%- else %}
             {%- set content = message.content %}
         {%- endif %}
-        {{- "<|im_start|>tool\n" + content|string + "<|im_end|>\n" }}
+        {{- "<|im_start|>tool\n<tool_response>\n" + content|string + "\n</tool_response><|im_end|>\n" }}
     {%- else %}
         {{- raise_exception("Only user and assistant and tool_results and tool and function roles are supported, with the exception of an initial optional system message!") }}
     {%- endif %}

--- a/tools/bielik_vllm_tool_parser.py
+++ b/tools/bielik_vllm_tool_parser.py
@@ -4,6 +4,7 @@ from typing import Union, Sequence
 
 import partial_json_parser
 from partial_json_parser.core.options import Allow
+from json_repair import repair_json  # pip install json-repair
 
 from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               DeltaFunctionCall, DeltaMessage,
@@ -16,6 +17,31 @@ from vllm.transformers_utils.tokenizer import AnyTokenizer, MistralTokenizer
 from vllm.utils import random_uuid
 
 logger = init_logger(__name__)
+
+
+def split_multiple_tool_calls(s: str) -> list[str]:
+    """Split multiple tool calls in one string.
+
+    Bielik sometimes generates: {"name": "A", ...}, {"name": "B", ...}
+    in one <tool_call> tag. This function splits them into separate objects.
+    """
+    # Pattern: }, { (with optional spaces and comma)
+    parts = re.split(r'\}\s*,\s*\{', s.strip())
+
+    if len(parts) == 1:
+        return [s]
+
+    # Add back braces removed by split
+    result = []
+    for i, part in enumerate(parts):
+        if i == 0:
+            result.append(part + '}')
+        elif i == len(parts) - 1:
+            result.append('{' + part)
+        else:
+            result.append('{' + part + '}')
+
+    return result
 
 
 @ToolParserManager.register_module("bielik")
@@ -58,46 +84,88 @@ class BielikToolParser(ToolParser):
         model_output: str,
         request: ChatCompletionRequest,
     ) -> ExtractedToolCallInformation:
+        """Extract tool calls from model output with JSON repair."""
 
-        # sanity check; avoid unnecessary processing
+        # Fast path - no tool calls
         if self.tool_call_start_token not in model_output:
-            return ExtractedToolCallInformation(tools_called=False,
-                                                tool_calls=[],
-                                                content=model_output)
-        else:
-            try:
-                # there are two possible captures - between tags, or between a
-                # tag and end-of-string so the result of
-                # findall is an array of tuples where one is a function call and
-                # the other is None
-                function_call_tuples = self.tool_call_regex.findall(model_output)
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output
+            )
 
-                # load the JSON, and then use it to build the Function and Tool Call
-                raw_function_calls = [
-                    json.loads(match[0] if match[0] else match[1])
-                    for match in function_call_tuples
-                ]
-                tool_calls = [
-                    ToolCall(
-                        type="function",
-                        function=FunctionCall(
-                            name=function_call["name"],
-                            # function call args are JSON but as a string
-                            arguments=json.dumps(function_call["arguments"],
-                                                 ensure_ascii=False)))
-                    for function_call in raw_function_calls
-                ]
+        try:
+            function_call_tuples = self.tool_call_regex.findall(model_output)
+            raw_function_calls = []
 
-                content = model_output[:model_output.find(self.tool_call_start_token)]
+            for match in function_call_tuples:
+                raw_content = match[0] if match[0] else match[1]
+                if not raw_content or not raw_content.strip():
+                    continue
+
+                # Split multiple tool calls in one tag
+                json_parts = split_multiple_tool_calls(raw_content)
+
+                for json_str in json_parts:
+                    json_str = json_str.strip()
+                    if not json_str:
+                        continue
+
+                    try:
+                        # Use json-repair to fix malformed JSON before parsing
+                        repaired = repair_json(json_str)
+                        if isinstance(repaired, str):
+                            parsed = json.loads(repaired)
+                        else:
+                            parsed = repaired  # json-repair can return dict
+
+                        if isinstance(parsed, dict) and "name" in parsed:
+                            raw_function_calls.append(parsed)
+                        else:
+                            logger.warning(f"Parsed JSON missing 'name' field: {parsed}")
+
+                    except Exception as e:
+                        logger.warning(f"Failed to parse tool call: {e}")
+                        logger.debug(f"Original JSON: {json_str[:200]}")
+
+            if not raw_function_calls:
+                logger.info("No valid tool calls found in output")
                 return ExtractedToolCallInformation(
-                    tools_called=True,
-                    tool_calls=tool_calls,
-                    content=content if content else None)
-            except Exception:
-                logger.exception("Error in extracting tool call from response.")
-                return ExtractedToolCallInformation(tools_called=False,
-                                                    tool_calls=[],
-                                                    content=model_output)
+                    tools_called=False,
+                    tool_calls=[],
+                    content=model_output
+                )
+
+            # Build ToolCall list with unique IDs
+            tool_calls = [
+                ToolCall(
+                    id=fc.get("id") or f"chatcmpl-tool-{random_uuid()}",
+                    type="function",
+                    function=FunctionCall(
+                        name=fc["name"],
+                        arguments=json.dumps(fc.get("arguments", {}), ensure_ascii=False)
+                    )
+                )
+                for fc in raw_function_calls
+            ]
+
+            # Extract content before first tool_call
+            content = model_output[:model_output.find(self.tool_call_start_token)]
+
+            logger.info(f"Successfully parsed {len(tool_calls)} tool call(s)")
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content.strip() if content.strip() else None
+            )
+
+        except Exception as e:
+            logger.exception(f"Unexpected error in extract_tool_calls: {e}")
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output
+            )
 
     def extract_tool_calls_streaming(
         self,

--- a/tools/test_parser_repair.py
+++ b/tools/test_parser_repair.py
@@ -1,0 +1,127 @@
+"""Unit tests for Bielik tool parser JSON repair functionality."""
+import pytest
+import json
+from json_repair import repair_json
+from bielik_vllm_tool_parser import split_multiple_tool_calls
+
+
+class TestSplitMultipleToolCalls:
+    """Tests for splitting multiple tool calls in one tag."""
+
+    def test_single_call(self):
+        """Single tool call should return list with one element."""
+        input_str = '{"name": "pods_list", "arguments": {"namespace": "test"}}'
+        result = split_multiple_tool_calls(input_str)
+        assert len(result) == 1
+        assert json.loads(result[0])["name"] == "pods_list"
+
+    def test_two_calls(self):
+        """Two tool calls should be split correctly."""
+        input_str = '{"name": "A", "arguments": {}}, {"name": "B", "arguments": {}}'
+        result = split_multiple_tool_calls(input_str)
+        assert len(result) == 2
+        assert json.loads(result[0])["name"] == "A"
+        assert json.loads(result[1])["name"] == "B"
+
+    def test_three_calls(self):
+        """Three tool calls should be split correctly."""
+        input_str = '{"name": "A"}, {"name": "B"}, {"name": "C"}'
+        result = split_multiple_tool_calls(input_str)
+        assert len(result) == 3
+
+    def test_with_whitespace(self):
+        """Whitespace between calls should be handled."""
+        input_str = '{"name": "A"}  ,  {"name": "B"}'
+        result = split_multiple_tool_calls(input_str)
+        assert len(result) == 2
+
+    def test_nested_objects(self):
+        """Nested objects should not be incorrectly split."""
+        input_str = '{"name": "test", "arguments": {"nested": {"key": "value"}}}'
+        result = split_multiple_tool_calls(input_str)
+        assert len(result) == 1
+        parsed = json.loads(result[0])
+        assert parsed["arguments"]["nested"]["key"] == "value"
+
+
+class TestJsonRepair:
+    """Tests for json-repair library with Bielik-specific cases."""
+
+    def test_unquoted_keys(self):
+        """Unquoted keys should be fixed."""
+        result = repair_json('{name: "test", arguments: {}}')
+        parsed = json.loads(result) if isinstance(result, str) else result
+        assert parsed["name"] == "test"
+
+    def test_trailing_comma(self):
+        """Trailing commas should be removed."""
+        result = repair_json('{"name": "test",}')
+        parsed = json.loads(result) if isinstance(result, str) else result
+        assert parsed["name"] == "test"
+
+    def test_missing_closing_brace(self):
+        """Missing closing brace should be added."""
+        result = repair_json('{"name": "test", "arguments": {"a": 1}')
+        parsed = json.loads(result) if isinstance(result, str) else result
+        assert parsed["name"] == "test"
+
+    def test_single_quotes(self):
+        """Single quotes should be converted to double quotes."""
+        result = repair_json("{'name': 'test'}")
+        parsed = json.loads(result) if isinstance(result, str) else result
+        assert parsed["name"] == "test"
+
+    def test_real_bielik_output_unquoted(self):
+        """Real Bielik output with unquoted keys should be fixed."""
+        bielik_output = '''{name: "pods_list_in_namespace", arguments: {namespace: "benchmark-t01"}}'''
+        result = repair_json(bielik_output)
+        parsed = json.loads(result) if isinstance(result, str) else result
+        assert parsed["name"] == "pods_list_in_namespace"
+        assert parsed["arguments"]["namespace"] == "benchmark-t01"
+
+    def test_real_bielik_output_mixed(self):
+        """Real Bielik output with mixed issues should be fixed."""
+        bielik_output = '''{name: "events_list", arguments: {namespace: "benchmark-t01", limit: 10,}}'''
+        result = repair_json(bielik_output)
+        parsed = json.loads(result) if isinstance(result, str) else result
+        assert parsed["name"] == "events_list"
+        assert parsed["arguments"]["namespace"] == "benchmark-t01"
+        assert parsed["arguments"]["limit"] == 10
+
+
+class TestIntegration:
+    """Integration tests combining split and repair."""
+
+    def test_multiple_malformed_calls(self):
+        """Multiple malformed calls should all be fixed."""
+        input_str = '{name: "A", arguments: {}}, {name: "B", arguments: {x: 1}}'
+        parts = split_multiple_tool_calls(input_str)
+        assert len(parts) == 2
+
+        for part in parts:
+            result = repair_json(part)
+            parsed = json.loads(result) if isinstance(result, str) else result
+            assert "name" in parsed
+            assert "arguments" in parsed
+
+    def test_complex_bielik_output(self):
+        """Complex Bielik output from benchmark should be handled."""
+        # This is a simplified version of real problematic output
+        bielik_output = '''{name: "pods_get", arguments: {name: "webapp-backend-xyz", namespace: "benchmark-t01"}}, {name: "pods_log", arguments: {name: "webapp-backend-xyz", namespace: "benchmark-t01", tail: 30}}'''
+
+        parts = split_multiple_tool_calls(bielik_output)
+        assert len(parts) == 2
+
+        results = []
+        for part in parts:
+            repaired = repair_json(part)
+            parsed = json.loads(repaired) if isinstance(repaired, str) else repaired
+            results.append(parsed)
+
+        assert results[0]["name"] == "pods_get"
+        assert results[1]["name"] == "pods_log"
+        assert results[1]["arguments"]["tail"] == 30
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

This PR improves the Bielik tool parser to handle malformed JSON output and adds proper tool call ID support for better OpenAI API compatibility.

## Problem

Bielik models sometimes generate malformed JSON in tool calls:
- **Unquoted keys**: `{name: "test"}` instead of `{"name": "test"}`
- **Multiple tool calls in one tag**: `<tool_call>{"name": "A"}, {"name": "B"}</tool_call>`
- **Missing closing braces**: `{"name": "test", "arguments": {"a": 1}`
- **Trailing commas**: `{"name": "test",}`

Additionally, the original parser didn't generate `tool_call.id` which is required by some OpenAI-compatible clients (e.g., n8n AI Agent).

## Solution

### 1. JSON Repair (`json-repair` library)
Uses the `json-repair` library to automatically fix malformed JSON before parsing. This is more robust than manual regex fixes.

### 2. Multiple Tool Call Splitting
New `split_multiple_tool_calls()` function handles cases where Bielik outputs multiple tool calls in a single `<tool_call>` tag.

### 3. Tool Call ID Generation
- Parser now generates unique IDs: `chatcmpl-tool-{uuid}`
- Chat template updated to include `id` field in tool call output

### 4. Improved Tool Response Format
Tool responses now wrapped in `<tool_response>` tags for cleaner parsing.

## Changes

| File | Description |
|------|-------------|
| `tools/bielik_vllm_tool_parser.py` | Added JSON repair, multiple call splitting, ID generation |
| `tools/bielik_advanced_chat_template.jinja` | Added tool_call.id and tool_response tags |
| `tools/test_parser_repair.py` | **New:** 13 unit tests for JSON repair functionality |
| `README.md` | Updated installation instructions |
| `run-vllm.bash` | Added example serve command |

## Installation

Requires `json-repair` package:
```bash
uv tool install --python 3.12 vllm==0.10.2 --with json-repair
```

## Testing

```bash
cd tools
uv run --with pytest --with json-repair --with partial-json-parser --with vllm==0.10.2 pytest test_parser_repair.py -v
```

```
test_parser_repair.py::TestSplitMultipleToolCalls::test_single_call PASSED
test_parser_repair.py::TestSplitMultipleToolCalls::test_two_calls PASSED
test_parser_repair.py::TestSplitMultipleToolCalls::test_three_calls PASSED
test_parser_repair.py::TestSplitMultipleToolCalls::test_with_whitespace PASSED
test_parser_repair.py::TestSplitMultipleToolCalls::test_nested_objects PASSED
test_parser_repair.py::TestJsonRepair::test_unquoted_keys PASSED
test_parser_repair.py::TestJsonRepair::test_trailing_comma PASSED
test_parser_repair.py::TestJsonRepair::test_missing_closing_brace PASSED
test_parser_repair.py::TestJsonRepair::test_single_quotes PASSED
test_parser_repair.py::TestJsonRepair::test_real_bielik_output_unquoted PASSED
test_parser_repair.py::TestJsonRepair::test_real_bielik_output_mixed PASSED
test_parser_repair.py::TestIntegration::test_multiple_malformed_calls PASSED
test_parser_repair.py::TestIntegration::test_complex_bielik_output PASSED

============================================ 13 passed ============================================
```

## Compatibility

- ✅ Tested with vLLM 0.10.2
- ✅ Backward compatible - no breaking changes to existing API
- ✅ Works with n8n AI Agent nodes via OpenAI-compatible endpoint