### PR TITLE
feat: enable thinking is false by default; better tool handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,25 @@ vllm serve Bielik-11B-v2.5-Instruct \
     --chat-template ./bielik-tools/tools/bielik_advanced_chat_template.jinja
 ```
 
-Note: For vLLM version 0.12.0 and below, use `bielik-tools/tools/bielik_vllm_tool_parser_v0.12.0.py` instead of `bielik-tools/tools/bielik_vllm_tool_parser.py`.
+Choose the tool parser file matching your vLLM version:
+
+| vLLM version | Tool parser | Reasoning parser |
+|---|---|---|
+| ≥ 0.15.0 | `bielik_vllm_tool_parser.py` | `bielik_vllm_reasoning_parser.py` |
+| 0.13.0 – 0.14.x | `bielik_vllm_tool_parser_v0.13.0.py` | `bielik_vllm_reasoning_parser_v0.13.0.py` |
+| ≤ 0.12.0 | `bielik_vllm_tool_parser_v0.12.0.py` | — |
 
 Then, run [tool\_calling.py](https://github.com/speakleash/bielik-tools/blob/main/examples/tool_calling.py) or [tool\_calling\_streaming.py](https://github.com/speakleash/bielik-tools/blob/main/examples/tool_calling_streaming.py) to see how tool calling works in practice.
 
 ## Reasoning
 
-Reasoning is currently available only in the Bielik 11B v2.5 Instruct model and is considered an experimental feature. Enabling reasoning allows the model to better handle complex questions by expanding its reasoning capabilities. To try it out, start vLLM with the following command:
+Reasoning is available in Bielik 11B v2.5 Instruct and Bielik v3.0 Instruct models. Enabling reasoning allows the model to better handle complex questions by expanding its reasoning capabilities. To try it out, start vLLM with the following command:
 
 ```bash
-vllm serve Bielik-11B-v2.5-Instruct \
+vllm serve speakleash/Bielik-11B-v3.0-Instruct \
     --chat-template ./bielik-tools/tools/bielik_advanced_chat_template.jinja \
-    --reasoning-parser deepseek_r1 \
+    --reasoning-parser-plugin ./bielik-tools/tools/bielik_vllm_reasoning_parser.py \
+    --reasoning-parser bielik \
     --enable-reasoning
 ```
 
@@ -60,7 +67,7 @@ TAVILY_API_KEY=tvly-apikey123123123123
 Run vllm
 
 ```bash
-vllm serve Bielik-11B-v2.5-Instruct \
+vllm serve speakleash/Bielik-11B-v3.0-Instruct \
     --enable-auto-tool-choice \
     --tool-parser-plugin ./bielik-tools/tools/bielik_vllm_tool_parser.py \
     --tool-call-parser bielik \

--- a/examples/reasoning_streaming.py
+++ b/examples/reasoning_streaming.py
@@ -4,8 +4,8 @@ from termcolor import colored
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-model = "leto/Bielik-11B-v3.0-Instruct" # Replace with your desired model
-client = OpenAI(api_key="sk-KqKz4rnJm3FYKKT86hiD7Q", base_url="https://litellm.test.gaiuslex.pl/v1") # Adjust if needed
+model = "speakleash/Bielik-11B-v3.0-Instruct" # Replace with your desired model
+client = OpenAI(api_key="EMPTY", base_url="http://127.0.0.1:8000/v1") # Adjust if needed
 logging.info(f"Using model: {model}")
 
 role_to_color = {

--- a/examples/reasoning_streaming.py
+++ b/examples/reasoning_streaming.py
@@ -4,8 +4,8 @@ from termcolor import colored
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-model = "Bielik-11B-v2.5-Instruct" # Replace with your desired model
-client = OpenAI(api_key="EMPTY", base_url="http://127.0.0.1:8000/v1") # Adjust if needed
+model = "leto/Bielik-11B-v3.0-Instruct" # Replace with your desired model
+client = OpenAI(api_key="sk-KqKz4rnJm3FYKKT86hiD7Q", base_url="https://litellm.test.gaiuslex.pl/v1") # Adjust if needed
 logging.info(f"Using model: {model}")
 
 role_to_color = {

--- a/tools/bielik_advanced_chat_template.jinja
+++ b/tools/bielik_advanced_chat_template.jinja
@@ -35,9 +35,13 @@
         {{- "\n\n" }}
     {%- endif %}
     {{- "You are provided with tool signatures that you can use to assist with the user's query. " }}
+    {%- if tool_choice is defined and tool_choice == "required" %}
+    {{- "You MUST invoke at least one tool to respond to the user's query. Do not answer without calling a tool first.\n" }}
+    {%- else %}
     {{- "You do not have to use a tool if you can respond adequately without it. " }}
     {{- "Do not make assumptions about the values to use in tool calls. " }}
     {{- "If the user's message is missing required parameters or if you do not have an appropriate tool to fulfill the request, inform the user or ask for clarification instead of attempting to call any tools.\n\n" }}
+    {%- endif %}
     {{- "If you decide to invoke a tool, you MUST use the following JSON format:\n" }}
     {{- "`<tool_call>{\"name\": <tool-name>, \"arguments\": <args-dict>}</tool_call>`\n\n" }}
     {{- "Below is a list of tools in JSON format that you can invoke:" }}

--- a/tools/bielik_vllm_reasoning_parser.py
+++ b/tools/bielik_vllm_reasoning_parser.py
@@ -1,0 +1,66 @@
+from collections.abc import Sequence
+
+from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
+                                               DeltaMessage,
+                                               ResponsesRequest)
+from vllm.reasoning import ReasoningParser, ReasoningParserManager
+from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+from vllm.reasoning.identity_reasoning_parser import IdentityReasoningParser
+from vllm.tokenizers import TokenizerLike
+
+
+@ReasoningParserManager.register_module("bielik")
+class BielikReasoningParser(ReasoningParser):
+    """
+    Reasoning parser for Bielik models.
+
+    Delegates to DeepSeekR1ReasoningParser when thinking is enabled
+    (``enable_thinking=True`` in ``chat_template_kwargs``), and to
+    IdentityReasoningParser otherwise — so that the entire model output
+    is returned as content, not reasoning.
+    """
+
+    def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):
+        super().__init__(tokenizer, *args, **kwargs)
+
+        chat_kwargs = kwargs.get("chat_template_kwargs") or {}
+        enable_thinking = bool(chat_kwargs.get("enable_thinking", False))
+
+        if enable_thinking:
+            self._parser = DeepSeekR1ReasoningParser(tokenizer, *args, **kwargs)
+        else:
+            self._parser = IdentityReasoningParser(tokenizer, *args, **kwargs)
+
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        return self._parser.is_reasoning_end(input_ids)
+
+    def is_reasoning_end_streaming(
+        self, input_ids: list[int], delta_ids: list[int]
+    ) -> bool:
+        return self._parser.is_reasoning_end_streaming(input_ids, delta_ids)
+
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        return self._parser.extract_content_ids(input_ids)
+
+    def extract_reasoning(
+        self, model_output: str, request: ChatCompletionRequest | ResponsesRequest
+    ) -> tuple[str | None, str | None]:
+        return self._parser.extract_reasoning(model_output, request)
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        return self._parser.extract_reasoning_streaming(
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+        )

--- a/tools/bielik_vllm_reasoning_parser_v0.13.0.py
+++ b/tools/bielik_vllm_reasoning_parser_v0.13.0.py
@@ -1,10 +1,8 @@
 from collections.abc import Sequence
 
-from vllm.entrypoints.openai.chat_completion.protocol import (
-    ChatCompletionRequest,
-)
-from vllm.entrypoints.openai.engine.protocol import DeltaMessage
-from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
+                                               DeltaMessage,
+                                               ResponsesRequest)
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
 from vllm.reasoning.identity_reasoning_parser import IdentityReasoningParser

--- a/tools/bielik_vllm_tool_parser.py
+++ b/tools/bielik_vllm_tool_parser.py
@@ -52,6 +52,11 @@ class BielikToolParser(ToolParser):
             # do not skip special tokens because Bielik uses the special tokens
             # to indicated the start and end of the tool calls information.
             request.skip_special_tokens = False
+            # Bielik uses <tool_call> tags instead of guided JSON decoding,
+            # so "required" must go through the auto tool-parser path;
+            # otherwise vLLM tries to validate the raw output as JSON.
+            if request.tool_choice == "required":
+                request.tool_choice = "auto"
         return request
 
     def extract_tool_calls(

--- a/tools/bielik_vllm_tool_parser.py
+++ b/tools/bielik_vllm_tool_parser.py
@@ -67,7 +67,7 @@ class BielikToolParser(ToolParser):
                 request.tool_choice = "auto"
                 request.response_format = None
                 request.structured_outputs = StructuredOutputsParams(
-                    regex=r"(<think>[^<]*</think>\s*)?(<tool_call>[^<]+</tool_call>\s*)"
+                    regex=r"(<think>[^<]*</think>\s*)?(<tool_call>[^<]+</tool_call>)"
                 )
         return request
 

--- a/tools/bielik_vllm_tool_parser.py
+++ b/tools/bielik_vllm_tool_parser.py
@@ -67,7 +67,7 @@ class BielikToolParser(ToolParser):
                 request.tool_choice = "auto"
                 request.response_format = None
                 request.structured_outputs = StructuredOutputsParams(
-                    regex=r"(<think>[^<]*</think>\s*)?(<tool_call>[^<]+</tool_call>\s*)+"
+                    regex=r"(<think>[^<]*</think>\s*)?(<tool_call>[^<]+</tool_call>\s*)"
                 )
         return request
 

--- a/tools/bielik_vllm_tool_parser_v0.13.0.py
+++ b/tools/bielik_vllm_tool_parser_v0.13.0.py
@@ -5,13 +5,11 @@ from typing import Union, Sequence
 import partial_json_parser
 from partial_json_parser.core.options import Allow
 
-from vllm.entrypoints.openai.chat_completion.protocol import (
-    ChatCompletionRequest,
-)
-from vllm.entrypoints.openai.engine.protocol import (
-    DeltaFunctionCall, DeltaMessage, DeltaToolCall,
-    ExtractedToolCallInformation, FunctionCall, ToolCall,
-)
+from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
+                                              DeltaFunctionCall, DeltaMessage,
+                                              DeltaToolCall,
+                                              ExtractedToolCallInformation,
+                                              FunctionCall, ToolCall)
 from vllm.logger import init_logger
 from vllm.sampling_params import StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike


### PR DESCRIPTION
Problem 1: Current implementation of reasoning parser enables reasoning by default, but doesn't parse it correctly. 
This fix changes the default reasoning setting to false, allowing better control over parsing.

Problem 2: Current implementation of tool parser doesn't work while setting `"tool_choice": "required"` due to json parsing error. This fix mitigates this issue.

